### PR TITLE
fix: use new ssbc name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: CC0-1.0
 
-module go.mindeco.de/ssb-refs
+module github.com/ssbc/go-ssb-refs
 
 go 1.14
 

--- a/tfk/encoding.go
+++ b/tfk/encoding.go
@@ -8,7 +8,7 @@ import (
 	"encoding"
 	"fmt"
 
-	refs "go.mindeco.de/ssb-refs"
+	refs "github.com/ssbc/go-ssb-refs"
 )
 
 // Encode returns type-format-key bytes for supported references.

--- a/tfk/encoding_test.go
+++ b/tfk/encoding_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	refs "go.mindeco.de/ssb-refs"
-	"go.mindeco.de/ssb-refs/tfk"
+	refs "github.com/ssbc/go-ssb-refs"
+	"github.com/ssbc/go-ssb-refs/tfk"
 )
 
 func mustMakeFeed(t *testing.T, hash []byte, algo refs.RefAlgo) refs.FeedRef {

--- a/tfk/feed.go
+++ b/tfk/feed.go
@@ -7,7 +7,7 @@ package tfk
 import (
 	"fmt"
 
-	refs "go.mindeco.de/ssb-refs"
+	refs "github.com/ssbc/go-ssb-refs"
 )
 
 // Feed represents a reference to a feed

--- a/tfk/message.go
+++ b/tfk/message.go
@@ -7,7 +7,7 @@ package tfk
 import (
 	"fmt"
 
-	refs "go.mindeco.de/ssb-refs"
+	refs "github.com/ssbc/go-ssb-refs"
 )
 
 // Message represents a reference to a message


### PR DESCRIPTION
Unsure what this will break :grimacing: 

Motivation: https://github.com/ssbc/go-ssb/issues/160